### PR TITLE
Implement testing and add `help` command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,11 @@ jobs:
         run: pip install -e .[test]
       - name: Run tests
         run: pytest tests -n 4 --cov --cov-report=term-missing --junitxml=test_report.xml
+        env:
+          TAULUBOT_TOKEN: ${{ secrets.TAULUBOT_TOKEN_TEST }}
+          TELEGRAM_APP_ID: ${{ secrets.TELEGRAM_APP_ID }}
+          TELEGRAM_APP_HASH: ${{ secrets.TELEGRAM_APP_HASH }}
+          TELETHON_SESSION: ${{ secrets.TELETHON_SESSION }}
       - name: Upload test results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.pylintrc
+++ b/.pylintrc
@@ -10,6 +10,7 @@ max-line-length=120
 [MESSAGES CONTROL]
 disable=
     arguments-differ,
+    consider-using-with,
     fixme,
     missing-class-docstring,
     missing-function-docstring,

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ Instead of 3. one can alternatively open a Python shell and run
 3. Start coding!
 
 
+## Testing
+
+Testing requires valid _TAULUBOT_TOKEN_TEST, TELEGRAM_APP_ID, TELEGRAM_APP_HASH,_ and _TELETHON_SESSION_ environment variables. 
+Refer to [this guide on how to generate them](https://blog.1a23.com/2020/03/06/how-to-write-integration-tests-for-a-telegram-bot/).
+After these are set up, tests can be run with:
+```bash
+pytest tests
+```
+
+
 ## Frames
 
 #### Normal

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,13 @@ setup(
     ],
     extras_require={
         "test": [
-            "pytest>=6.1",
-            "pytest-sugar>=0.9",
-            "pytest-cov>=2.12",
-            "pytest-xdist>=2.3",
-            "pylint>=2.9"
+            "pylint~=2.9",
+            "pytest-asyncio~=0.15",
+            "pytest-cov~=2.12",
+            "pytest-sugar~=0.9",
+            "pytest-xdist~=2.3",
+            "pytest~=6.1",
+            "telethon~=1.23",
         ],
     },
 )

--- a/taulubot/main.py
+++ b/taulubot/main.py
@@ -5,6 +5,7 @@ from random import random
 
 import requests
 from PIL import Image
+from telegram import ParseMode
 from telegram.ext import Updater, CommandHandler
 
 os.chdir(os.path.dirname(os.path.abspath(__file__)))  # workdir to __file__ location
@@ -31,6 +32,8 @@ def taulu(update, context):
     chat_id = update.message.chat.id
 
     query = context.bot.get_user_profile_photos(user_id, limit=1)
+    if query.total_count == 0:
+        return update.message.reply_text('Teillä ei ole profiilikuvaa!')
     photo = query.photos[0][-1].get_file()
     url = photo.file_path
 
@@ -51,7 +54,15 @@ def taulu(update, context):
 
     with open(filename, 'rb') as f:
         context.bot.send_photo(chat_id, f)
-    os.remove(filename)
+    return os.remove(filename)
+
+
+def help_handle(update, context):  # pylint: disable=unused-argument
+    """Send info on /help"""
+    update.message.reply_text("Lisää profiilikuvallesi kehys lähettämällä /taulu\n\n" +
+        "Tietoa Fyysikkospeksistä löydät osoitteesta [fyysikkospeksi.fi](https://fyysikkospeksi.fi/)",
+        parse_mode=ParseMode.MARKDOWN
+    )
 
 
 def error(update, context):
@@ -72,6 +83,7 @@ def main():
 
     # on different commands - answer in Telegram
     dp.add_handler(CommandHandler("taulu", taulu))
+    dp.add_handler(CommandHandler("help", help_handle))
 
     # log all errors
     dp.add_error_handler(error)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+import asyncio
+import os
+import subprocess
+
+import pytest
+from telethon import TelegramClient
+from telethon.sessions import StringSession
+
+api_id = int(os.environ["TELEGRAM_APP_ID"])
+api_hash = os.environ["TELEGRAM_APP_HASH"]
+session_str = os.environ["TELETHON_SESSION"]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def server():
+    """ Start the Bot before testing """
+    process = subprocess.Popen(['python', '-c', "from taulubot.main import main;main()"])  # , shell=True, check=True)
+    yield process
+    # executed after last test
+    process.kill()
+
+
+@pytest.fixture(scope="session")
+async def client() -> TelegramClient:
+    """Set up Telegram Client to interact w/ bot"""
+    tg_client = TelegramClient(
+        StringSession(session_str), api_id, api_hash,
+        sequential_updates=True
+    )
+    # Connect to the server
+    await tg_client.connect()
+    await tg_client.get_me()
+    await tg_client.get_dialogs()
+
+    yield tg_client
+
+    await tg_client.disconnect()
+    await tg_client.disconnected
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Create an instance of the default event loop for all test cases."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,31 @@
+import pytest
+from telethon import TelegramClient
+from telethon.tl.custom.message import Message
+
+
+@pytest.mark.asyncio
+async def test_help(client: TelegramClient):
+    # Test the /help command
+    async with client.conversation("fyysikkospeksi_taulubot", timeout=10) as conv:
+        # Send a command
+        await conv.send_message("/help")
+        # Get response
+        resp: Message = await conv.get_response()
+        # Make assertions
+        assert "/taulu" in resp.text
+
+
+@pytest.mark.skip(reason="Fetching a photo from TG test server is harder than changing base_url")
+@pytest.mark.asyncio
+async def test_taulu(client: TelegramClient):
+    # Test the /taulu command
+    async with client.conversation("fyysikkospeksi_taulubot", timeout=15) as conv:
+        # Test w/ profile picture
+        # await client(UploadProfilePhotoRequest(
+        #     await client.upload_file('./taulubot/images/frame.png')
+        # ))
+
+        await conv.send_message("/taulu")
+        resp: Message = await conv.get_response()
+
+        assert resp.photo

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -1,5 +1,0 @@
-def test_frame():
-    """
-    TODO implement
-    """
-    pass


### PR DESCRIPTION
This PR:

- implements testing using Telethon and Telegram Testing server following [this guide](https://blog.1a23.com/2020/03/06/how-to-write-integration-tests-for-a-telegram-bot/).
- add help command with info

Closes #6