### PR TITLE
Add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Fyysikkokilta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Telegram bot for adding a [_Fyysikkospeksi_](https://fyysikkospeksi.fi/) related
 
 Forked from [EinariTuukkanen/telegram-bots](https://github.com/EinariTuukkanen/telegram-bots).
 
+Code licensed under MIT license and pictures under CC0 1.0.
 
 ## Deploying
 
@@ -17,7 +18,7 @@ Forked from [EinariTuukkanen/telegram-bots](https://github.com/EinariTuukkanen/t
     ```bash
     docker run -d --restart unless-stopped --env-file .env ghcr.io/fyysikkokilta/fyysikkospeksi-taulubot:main
     ```
-    _Optionally_, to override the frame images, you can mount a folder with your images to `/taulu/taulubot/images`. 
+    _Optionally_, to override the frame images, you can mount a folder with your images to `/taulu/taulubot/images`.
     Mounting the current folder as read-only works as follows:
     ```bash
     docker run -d --volume ${pwd}:/taulu/taulubot/images:ro --env-file .env ghcr.io/fyysikkokilta/fyysikkospeksi-taulubot:main
@@ -39,7 +40,7 @@ Instead of 3. one can alternatively open a Python shell and run
    from taulubot.main import main
    main()
    ```
-   
+
 ## Development
 
 1. Clone the repo
@@ -56,7 +57,7 @@ Instead of 3. one can alternatively open a Python shell and run
 
 ## Testing
 
-Testing requires valid _TAULUBOT_TOKEN_TEST, TELEGRAM_APP_ID, TELEGRAM_APP_HASH,_ and _TELETHON_SESSION_ environment variables. 
+Testing requires valid _TAULUBOT_TOKEN_TEST, TELEGRAM_APP_ID, TELEGRAM_APP_HASH,_ and _TELETHON_SESSION_ environment variables.
 Refer to [this guide on how to generate them](https://blog.1a23.com/2020/03/06/how-to-write-integration-tests-for-a-telegram-bot/).
 After these are set up, tests can be run with:
 ```bash

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ![Fyysikkospeksi logo](taulubot/images/speksilogo.png)
 
 ![example workflow](https://github.com/fyysikkokilta/fyysikkospeksi-taulubot/actions/workflows/ci.yaml/badge.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Pictures: CC0-1.0](https://img.shields.io/badge/Pictures-CC0_1.0-lightgrey.svg)](http://creativecommons.org/publicdomain/zero/1.0/)
 
 Telegram bot for adding a [_Fyysikkospeksi_](https://fyysikkospeksi.fi/) related frame to user's profile picture.
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     author_email="tuottajat@fyysikkospeksi.fi",
     url="https://github.com/fyysikkokilta/fyysikkospeksi-taulubot",
     packages=['taulubot'],
+    license='MIT',
     python_requires=">=3.6.9,<3.10",
     install_requires=[
         "Pillow~=8.3",


### PR DESCRIPTION
Add MIT license for code and CC0 for images. MIT allows the code to be
re-used in other use cases. There aren't that many reasons to choose a
more restrictive license such as GPL or AGPL.

CC0 for images was chosen
so that the generated images can be used without referencing
Fyysikkospeksi as the original creator (CC BY would have issues with
maybe having to claim part author in TG bio or somewhere else).

The existing commits are by @nikosavola  and @summis so approval would be required by you if this is decided to be merged :)